### PR TITLE
bugfix/cron-job bulk order status update fix

### DIFF
--- a/src/Service/eSIMCoreService.php
+++ b/src/Service/eSIMCoreService.php
@@ -326,7 +326,9 @@ class eSIMCoreService
         try {
             $headers = $this->getHeaders($orderStatusCheckBulkRequest);
 
-            $payload = $orderStatusCheckBulkRequest->toArray();
+            $payload = [
+                'orders' => $orderStatusCheckBulkRequest->getOrders(),
+            ];
 
             $signatureDto = SignatureDto::builder()
                 ->setUrl($this->baseUri . self::ORDER_STATUS_CHECK_BULK_ROUTE)


### PR DESCRIPTION
[CRITICAL] Uncaught Error: Call to undefined method eSIM\eSIMCoreClient\Dto\Request\OrderStatusCheckBulkRequest::toArray() {"exception":"[object] (Error(code: 0): Call to undefined method eSIM\\eSIMCoreClient\\Dto\\Request\\OrderStatusCheckBulkRequest::toArray() at /data/projects/esim-backend/releases/20240603152421/vendor/esim/esim-core-client-sdk-php/src/Service/eSIMCoreService.php:288)

fix